### PR TITLE
use proper death check for wiz getEnemies

### DIFF
--- a/src/main/java/code/util/Wiz.java
+++ b/src/main/java/code/util/Wiz.java
@@ -62,7 +62,7 @@ public class Wiz {
 
     public static ArrayList<AbstractMonster> getEnemies() {
         ArrayList<AbstractMonster> monsters = new ArrayList<>(AbstractDungeon.getMonsters().monsters);
-        monsters.removeIf(m -> m.isDead || m.isDying);
+        monsters.removeIf(AbstractCreature::isDeadOrEscaped);
         return monsters;
     }
 


### PR DESCRIPTION
Basegame uses isDeadOrEscaped() to determine if enemies in a room are dead or not (See Bowling Bash for an example).  For maximum compatibility, the Wiz getEnemies method should use the same method for consistency.